### PR TITLE
Limit special characters to standard ASCII

### DIFF
--- a/src/popup/pwgen.js
+++ b/src/popup/pwgen.js
@@ -1,7 +1,7 @@
 function randPassword(length, includeSpecial, exclude) {
   let pwdChars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
   if (includeSpecial) {
-    pwdChars += '°^!"§$%&/()=?`´\\}][{²³€|<>-.,;:*+_µ@~';
+    pwdChars += '!"#$%&\'()*+,-./:;<=>?`[\\~]^_@{|}';
   }
 
   if (exclude) {


### PR DESCRIPTION
This will allow a broader public to enter the passwords manually more easily, as well as get the password accepted more by websites by default.

Personally I'd love to add a space character as well, since it's a perfectly acceptable character, but this tends to be refused by websites a lot.